### PR TITLE
chore: disable debug logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk --no-cache add \
     openldap-passwd-argon2 \
  && mkdir -p /run/openldap
 
-CMD ["/usr/sbin/slapd", "-d", "448", "-h", "ldap://0.0.0.0:389/ ldapi://%2fvar%2frun%2fsockets%2fslapd.sock"]
+CMD ["/usr/sbin/slapd", "-h", "ldap://0.0.0.0:389/ ldapi://%2fvar%2frun%2fsockets%2fslapd.sock"]


### PR DESCRIPTION
Can be enabled again by overriding docker CMD
