### PR TITLE
chore: turn logging back on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk --no-cache add \
     openldap-passwd-argon2 \
  && mkdir -p /run/openldap
 
-CMD ["/usr/sbin/slapd", "-h", "ldap://0.0.0.0:389/ ldapi://%2fvar%2frun%2fsockets%2fslapd.sock"]
+CMD ["/usr/sbin/slapd", "-d", "none", "-h", "ldap://0.0.0.0:389/ ldapi://%2fvar%2frun%2fsockets%2fslapd.sock"]


### PR DESCRIPTION
Without logging enabled on the CLI, slapd forks off, which is not what we want in this context. `stats` is the default, and `config` is useful for debugging container startup and shouldn't affect the log volume considerably.
